### PR TITLE
Tequila adoption prep

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,8 @@
                    password="{{ db_password }}"
                    encrypted=yes
   become_user: postgres
+  vars:
+    ansible_ssh_pipelining: true
 
 - name: create the project database
   postgresql_db: name="{{ db_name }}"
@@ -35,6 +37,8 @@
                  lc_ctype='en_US.UTF-8'
                  template='template0'
   become_user: postgres
+  vars:
+    ansible_ssh_pipelining: true
 
 - name: configure postgres authentication
   template: src="pg_hba.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,5 +51,5 @@
     - restart postgres
 
 - name: allow app minions through the firewall
-  ufw: rule=allow port=5432 from_ip={{ hostvars[item].ansible_eth0.ipv4.address }}
+  ufw: rule=allow port=5432 from_ip={{ hostvars[item].ansible_default_ipv4.address }}
   with_items: "{{ app_minions }}"

--- a/templates/postgresql.conf
+++ b/templates/postgresql.conf
@@ -182,7 +182,9 @@ commit_siblings = {{ postgresql_config.commit_siblings | default('5') }}        
 
 # - Checkpoints -
 
+{% if pg_version | version_compare('9.5', '<') %}
 checkpoint_segments = {{ postgresql_config.checkpoint_segments | default('32') }}           # in logfile segments, min 1, 16MB each
+{% endif %}
 checkpoint_timeout = {{ postgresql_config.checkpoint_timeout | default('10min') }}      # range 30s-1h
 checkpoint_completion_target = {{ postgresql_config.checkpoint_completion_target | default('0.9') }}    # checkpoint target duration, 0.0 - 1.0
 #checkpoint_warning = 30s       # 0 disables


### PR DESCRIPTION
- support the removal of the `checkpoint_segments` variable in Postgres 9.5
- stop hard-coding the default interface to check for the ip address
- pipeline the commands where we become the postgres user, since newer versions of Ansible close a security loophole having to do with world-readable script snippets that it uses