### PR TITLE
Add Postgres repo and its key before trying to install Postgres

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   apt_repository:
     repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
     update_cache: yes
+    filename: "pgdg"
 
 - name: install postgres
   apt: name={{ item }} state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: add key for postgres repo
+  apt_key:
+    id: ACCC4CF8
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    state: present
+
+- name: add postgres repo to apt sources
+  apt_repository:
+    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+    update_cache: yes
+
 - name: install postgres
   apt: name={{ item }} state=present
   with_items:


### PR DESCRIPTION
When trying to provision a new server for a side project during a recent weekend work session, I hit a problem where tequila-postgresql was failing to install Postgres 11. The solution to this appeared to be to SSH in and add the repo (and its key) to apt. It seems that we've encountered similar problems on other projects and added the relevant steps to a "bootstrap DB" playbook. We should add it to tequila-postgresql, since many projects will encounter this issue during provisioning.