### PR TITLE
Point the postgres repo at the archive

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: add postgres repo to apt sources
   apt_repository:
-    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+    repo: "deb http://apt-archive.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg-archive main"
     update_cache: yes
     filename: "pgdg"
 


### PR DESCRIPTION
This is necessary for SGA deploys at the moment.