### PR TITLE
Use archive APT repos for Ubuntu releases older than 18.*

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,13 @@ role:
 - ``db_password`` **required**
 - ``pg_version`` **default:** 9.3
 - ``postgresql_config`` **default:** empty dict
+- ``min_supported_ubuntu_release`` **default:** 18
 - ``app_minions`` **required:** combined list of web servers and celery worker servers
+
+``min_supported_ubuntu_release`` is the major version number of the oldest
+Ubuntu release currently supported by PostgreSQL's currently-supported APT
+repositories.  PostgreSQL's archive repositories will be used for older Ubuntu
+releases.
 
 The ``app_minions`` variable can be constructed from Ansible's
 inventory information, like ::

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ postgresql_config: {}
 db_role: "master"
 db_name: "{{ project_name }}_{{ env_name }}"
 db_user: "{{ project_name }}_{{ env_name }}"
+# Minimum actively-supported Ubuntu release for postgresql.org APT repo
+# The archive repo will be used for older Ubuntu releases.
+min_supported_ubuntu_release: 18

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,18 @@
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     state: present
 
+- name: decide if archive repo is necessary for this host
+  set_fact:
+    use_archive_repo: "{{ ansible_distribution_major_version|int < min_supported_ubuntu_release }}"
+
+- name: set host Ubuntu version-specific portions of repository
+  set_fact:
+    repo_host: "{{ 'apt-archive' if use_archive_repo else 'apt' }}"
+    package: "{{ 'pgdg-archive' if use_archive_repo else 'pgdg' }}"
+
 - name: add postgres repo to apt sources
   apt_repository:
-    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+    repo: "deb http://{{ repo_host }}.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-{{ package }} main"
     update_cache: yes
     filename: "pgdg"
 


### PR DESCRIPTION
Like #6, this introduces the use of the postgresql.org "archive" APT repos, but it does so only for Ubuntu < 18.